### PR TITLE
auto set the compiler and fix up the errorformat

### DIFF
--- a/compiler/exunit.vim
+++ b/compiler/exunit.vim
@@ -16,7 +16,7 @@ let s:cpo_save = &cpo
 set cpo-=C
 
 CompilerSet makeprg=mix\ test
-CompilerSet errorformat=%A\ \ %.)\ %m(%.%#),%C\ \ \ \ \ **%m,%C\ \ \ \ \ \ \ %m,%Z\ \ \ \ \ at\ %f:%l,%-G%.%#
+CompilerSet errorformat=%E==\ Compilation\ error\ %.%#,%C**\ (%[%^)]%#)\ %f:%l:\ %m,%-C\ \ \ \ (%.%#,%E\ \ %*\\d)\ %.%#,%C\ \ \ \ \ stacktrace:,%C\ \ \ \ \ \ \ (%[%^)]%#)\ %f:%l:\ %.%#,%C\ \ \ \ \ \ \ %f:%l,%C\ \ \ \ \ %[%^:]%#:%*\\d,%C\ \ \ \ \ %m,%-G%.%#
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -23,3 +23,5 @@ endif
 
 setlocal comments=:#
 setlocal commentstring=#\ %s
+
+compiler exunit


### PR DESCRIPTION
errorformat should now pull the assertion/error message out for the
quickfix message and properly look for the top of the stacktrace
for the file and line location. seems to  handle mix output of
compiler errors, test errors (such as assertions), and runtime errors
(such as argument or clause errors)
